### PR TITLE
Exclude previous_breaking_changes_size from end-of-file-fixer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
       #   newline will need multiple runs.
       - id: trailing-whitespace
       - id: end-of-file-fixer
+        exclude: ^stored_state/breaking_changes_update_notice/previous_breaking_changes_size$
       - id: mixed-line-ending
 
   - repo: https://github.com/oxc-project/mirrors-oxfmt


### PR DESCRIPTION
This file stores a raw byte size and must not have a trailing newline
appended, since that would corrupt the stored value.